### PR TITLE
Split up basic test case to ease extending

### DIFF
--- a/datastore/core/test/test_basic.py
+++ b/datastore/core/test/test_basic.py
@@ -56,6 +56,7 @@ class TestDatastore(unittest.TestCase):
 
   def check_query(self, query, total, slice):
     allitems = list(range(0, total))
+    resultset = None
 
     for sn in self.stores:
       try:


### PR DESCRIPTION
Split up the subtest_simple into a number of smaller methods that allow for easier partial overriding of the test case. Ultimately I think it'd be nicer if these were individual test cases. They're structured now so that they can become so, but it would break backwards compatibility.
