### PR TITLE
Allow filtering over None values

### DIFF
--- a/datastore/core/query.py
+++ b/datastore/core/query.py
@@ -146,7 +146,7 @@ class Filter(object):
 
     # TODO: which way should the direction go here? it may make more sense to
     #       convert the passed-in value instead. Or try both? Or not at all?
-    if not isinstance(value, self.value.__class__) and not self.value is None:
+    if not isinstance(value, self.value.__class__) and not self.value is None and not value is None:
       value = self.value.__class__(value)
 
     return self.valuePasses(value)

--- a/datastore/core/test/test_query.py
+++ b/datastore/core/test/test_query.py
@@ -224,6 +224,10 @@ class TestFilter(unittest.TestCase):
     vs = [{'val': None}, {'val': 'something'}]
     self.assertFilter(feqnone, vs, vs[0:1])
 
+    feqzero = Filter('val', '=', 0)
+    vs = [{'val': 0}, {'val': None}]
+    self.assertFilter(feqzero, vs, vs[0:1])
+
   def test_object(self):
     t1 = nanotime.now()
     t2 = nanotime.now()


### PR DESCRIPTION
Filtering over values that contains None values previously failed. This fixes it. For example, the following would fail:

```
eqzero = Filter('val','=',0)
Filter.filter(eqzero, [{'val': None}])
```
